### PR TITLE
Remove fixed-top from <nav> tag's class

### DIFF
--- a/application/views/include/nav.php
+++ b/application/views/include/nav.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
+<nav class="navbar navbar-expand-md navbar-dark bg-dark">
   <a class="navbar-brand" href="<?php echo base_url(); ?>">CCS</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Removed fixed-top from <nav> tag's class so body content won't overlap with navigation bar.